### PR TITLE
Fix checking battery level

### DIFF
--- a/DGTCentaurMods/opt/DGTCentaurMods/board/board.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/board/board.py
@@ -825,7 +825,9 @@ def getBatteryLevel():
             print(resp.hex())
             vall = resp[5] & 31
             return vall
-    
+        else:
+            # fix for when battery returns as None on first attempt
+            return getBatteryLevel()
 
 #
 # Miscellaneous functions - do they belong in this file?


### PR DESCRIPTION
When checking the battery level, something the method returns as None, the first time it is called. It doesn't happen always, but when it does, this should do the trick (tested locally).