### PR TITLE
Hint Enable/Disable funktion

### DIFF
--- a/DGTCentaurMods/opt/DGTCentaurMods/classes/CentaurConfig.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/classes/CentaurConfig.py
@@ -76,6 +76,15 @@ class CentaurConfig:
     def get_sound_settings(id:str)  -> bool:
         return CentaurConfig._get('sounds', id, '1') == '1'
 
+    # *edit by Chemtech1* - Hint settings methods
+    @staticmethod
+    def update_hint_settings(id:str, value:bool) -> None:
+        CentaurConfig._update('hint', id, '1' if value else '0', '1')
+
+    @staticmethod
+    def get_hint_settings(id:str)  -> bool:
+        return CentaurConfig._get('hint', id, '1') == '1'
+
     @staticmethod
     def update_lichess_settings(id:str, value:str) -> None:
         CentaurConfig._update('lichess', id, value, '')

--- a/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
@@ -998,19 +998,32 @@ class Engine():
         self._new_evaluation_requested = False
 
     def update_evaluation(self, expectation:float=None, force:bool=False, text:str=None, disabled:bool=False):
-        
+
         if not self._started:
             return
-        
+
         if force:
             self._new_evaluation_requested = False
             SCREEN.draw_evaluation_bar(text=text, expectation=expectation, disabled=disabled)
         else:
             self._new_evaluation_requested = True
 
+    def _clear_disabled_after_delay(self):
+        time.sleep(3)
+        self.update_evaluation(force=True, disabled=True)
+
     def flash_hint(self, thinking_time = 1):
 
         if not self._started:
+            return
+
+        # *edit by Chemtech1* - Check if hint is enabled in settings
+        from DGTCentaurMods.classes.CentaurConfig import CentaurConfig
+        if not CentaurConfig.get_hint_settings(consts.HINT_ENABLED):
+            self.update_evaluation(force=True, text="disabled")
+            timer = Thread(target=self._clear_disabled_after_delay)
+            timer.daemon = True
+            timer.start()
             return
 
         try:

--- a/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
@@ -1010,7 +1010,7 @@ class Engine():
 
     def _clear_disabled_after_delay(self):
         time.sleep(3)
-        self.update_evaluation(force=True, disabled=True)
+        self.update_evaluation()
 
     def flash_hint(self, thinking_time = 1):
 

--- a/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/classes/GameFactory.py
@@ -1020,7 +1020,7 @@ class Engine():
         # *edit by Chemtech1* - Check if hint is enabled in settings
         from DGTCentaurMods.classes.CentaurConfig import CentaurConfig
         if not CentaurConfig.get_hint_settings(consts.HINT_ENABLED):
-            self.update_evaluation(force=True, text="disabled")
+            self.update_evaluation(force=True, text="hint disabled")
             timer = Thread(target=self._clear_disabled_after_delay)
             timer.daemon = True
             timer.start()

--- a/DGTCentaurMods/opt/DGTCentaurMods/consts/consts.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/consts/consts.py
@@ -85,3 +85,10 @@ SOUNDS_SETTINGS = [
     { "id":SOUND_VICTORY,"label":"Victory music" },
     { "id":SOUND_GAME_LOST,"label":"Game lost/draw music" },
 ]
+
+# *edit by Chemtech1* - Hint settings configuration
+HINT_ENABLED = "hint_enabled"
+
+HINT_SETTINGS = [
+    { "id":HINT_ENABLED, "label":"Hint enabled" },
+]

--- a/DGTCentaurMods/opt/DGTCentaurMods/consts/menu.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/consts/menu.py
@@ -122,6 +122,12 @@ _MENU_ITEMS = [
                 Tag.ONLY_WEB: True,
                 Tag.ACTION: {Tag.TYPE: "socket_data", Tag.VALUE: "sounds_settings"},
             },
+            # *edit by Chemtech1* - Hint settings menu entry
+            {
+                Tag.LABEL: "💡 Hint on/off",
+                Tag.ONLY_WEB: True,
+                Tag.ACTION: {Tag.TYPE: "socket_data", Tag.VALUE: "hint_settings"},
+            },
         ],
     },
     {

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/app.py
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/app.py
@@ -393,6 +393,22 @@ def on_request(message):
 
 				socketio.emit('web_message', response)
 
+			# *edit by Chemtech1* - Hint settings handlers
+			if action == "hint_settings_set":
+
+				if "value" in message:
+					CentaurConfig.update_hint_settings(message["value"]["id"], message["value"]["value"])
+
+			if action == "hint_settings":
+
+				# We read the hint settings
+				for s in consts.HINT_SETTINGS:
+					s["value"] = CentaurConfig.get_hint_settings(s["id"])
+
+				response["hint_settings"] = consts.HINT_SETTINGS
+
+				socketio.emit('web_message', response)
+
 			if action == "game_moves":
 				response["game_moves"] = _dal.read_game_moves_by_id(message["id"])
 				socketio.emit('web_message', response)

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/client/src/components/HintSettings.vue
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/client/src/components/HintSettings.vue
@@ -21,18 +21,42 @@ This and any other notices must remain intact and unaltered in any
 distribution, modification, variant, or derivative of this software.
 -->
 
+<!-- *edit by Chemtech1* - Hint settings component -->
 <template>
-  <ConfirmColor />
-  <SoundSettings />
-  <HintSettings /> <!-- *edit by Chemtech1* - Hint settings component -->
-  <ViewPgn />
-  <WebSettings />
+  <dialog :class="['modal', { 'modal-open': hints.length }]">
+    <div class="modal-box">
+      <h3 class="font-bold">💡 Hint on/off</h3>
+      <div><ul class="menu">
+        <li v-for="hint in hints" :key="hint">
+          <label>
+            <input
+              @change="updateAppSetings(hint)"
+              class="toggle"
+              type="checkbox"
+              v-model="hint.value"
+            />
+            {{ hint.label }}
+          </label>
+        </li>
+      </ul></div>
+      <div class="modal-action">
+        <button @click="hints = []" class="btn btn-primary">Close</button>
+      </div>
+    </div>
+  </dialog>
 </template>
 
 <script setup lang="ts">
-import ConfirmColor from './ConfirmColor.vue'
-import SoundSettings from './SoundSettings.vue'
-import HintSettings from './HintSettings.vue' // *edit by Chemtech1* - Hint settings import
-import ViewPgn from './ViewPgn.vue'
-import WebSettings from './WebSettings.vue'
+import { dequeue, emit, inbound } from '../socket'
+import { shallowRef } from 'vue'
+
+const hints = shallowRef([])
+
+dequeue(inbound.hint_settings, (value) => {
+  hints.value = value
+})
+
+const updateAppSetings = (hint) => {
+  emit('request', { data: 'hint_settings_set', value: hint })
+}
 </script>

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/client/src/socket.ts
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/client/src/socket.ts
@@ -45,6 +45,7 @@ export const inbound = reactive({
   release: [],
   script_output: [],
   sounds_settings: [],
+  hint_settings: [], // *edit by Chemtech1* - Hint settings socket queue
   tip_uci_move: [],
   tip_uci_moves: [],
   turn_caption: [],

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/static/2.0/js/index.js
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/static/2.0/js/index.js
@@ -590,6 +590,20 @@ angular.module("dgt-centaur-mods", ['ngMaterial', 'angular-storage', 'ngAnimate'
 
 								},
 
+								// *edit by Chemtech1* - Legacy AngularJS support for hint settings
+								hint_settings: (value) => {
+
+									me.board.hints = value
+
+									$mdDialog.show({
+										contentElement: '#hint_settings',
+										parent: angular.element(document.body),
+										targetEvent: null,
+										clickOutsideToClose: true
+									})
+
+								},
+
 								// Previous games have been resquested
 								previous_games: (value) => {
 

--- a/DGTCentaurMods/opt/DGTCentaurMods/web/templates/2.0/index.html
+++ b/DGTCentaurMods/opt/DGTCentaurMods/web/templates/2.0/index.html
@@ -165,6 +165,15 @@
 						</div>
 					</md-dialog>
 					</div>
+					<!-- *edit by Chemtech1* - Legacy AngularJS support for hint settings -->
+					<div class="md-dialog-container" id="hint_settings">
+					<md-dialog layout-padding>
+						<h3>Hint on/off</h3>
+						<div class="smallfont" class="md-dense" layout="column" layout-align="center start">
+							<md-switch data-ng-repeat="item in main.board.hints" ng-click="main.updateAppSettings('hint_settings_set', item)" ng-model="item.value">[[item.label]]</md-switch>
+						</div>
+					</md-dialog>
+					</div>
 					<div class="md-dialog-container" id="previous_games">
 						<md-dialog layout-padding>
 							<h3>Previous games...</h3>


### PR DESCRIPTION
Implements a configurable hint function that allows players to turn the hint display on or off. The function displays the best move based on Stockfish analysis.

I find this feature very useful, as I tend to use the hint button a lot when I get stuck. I think many players do the same. Disabling this feature in the web interface means I have to think for myself.


#### Backend

- __`consts.py`__: New constants `HINT_ENABLED`, `HINT_SETTINGS` for configuration.
- __`CentaurConfig.py`__: Methods `update_hint_settings()`, `get_hint_settings()` for persistent storage.
- __`GameFactory.py`__: `flash_hint()` checks setting before execution.
- __`app.py`__: Handler for `hint_settings` and `hint_settings_set` socket messages.
- __`menu.py`__: Menu item “💡 Hint on/off” in Settings.

#### Frontend

- __`HintSettings.vue`__: New Vue component with checkbox for hint activation.
- __`App.vue`__: Import and integration of the HintSettings component.
- __`socket.ts`__: New queue `hint_settings` for data transfer.


Translated with DeepL.com (free version)